### PR TITLE
Update dependencies

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 *.log
 node_modules/
+package-lock.json
 .eslintcache
 
 

--- a/package.json
+++ b/package.json
@@ -11,9 +11,9 @@
     "depgraph": "mkdir -p build/ && (cd src/ && madge . --dot) > build/depgraph.gv",
     "depgraph-noext": "mkdir -p build/ && (cd src/ && madge . --dot -x \"`node -e \"console.log(Object.keys(require('../webpack.config').externals).map(s => '^'+s+'$').join('|'))\"`\") > build/depgraph-noext.gv",
     "lint": "eslint --cache webpack.config.js src/",
-    "prod": "export NODE_ENV=production; npm run lint && webpack --progress --colors --display-error-details",
-    "start": "webpack-dev-server --progress --colors --display-error-details --host=0.0.0.0",
-    "watch": "webpack --watch --progress --colors --display-error-details"
+    "prod": "export NODE_ENV=production; npm run lint && webpack --progress",
+    "start": "webpack serve --progress --host=0.0.0.0",
+    "watch": "webpack --watch --progress"
   },
   "devDependencies": {
     "eslint": "^7.26.0",

--- a/package.json
+++ b/package.json
@@ -15,12 +15,12 @@
     "start": "webpack-dev-server --progress --colors --display-error-details --host=0.0.0.0",
     "watch": "webpack --watch --progress --colors --display-error-details"
   },
-  "dependencies": {},
   "devDependencies": {
-    "eslint": "^3.0.0",
-    "file-loader": "^0.8.5",
-    "raw-loader": "^0.5.1",
-    "webpack": "^1.12.9",
-    "webpack-dev-server": "^1.16.5"
+    "eslint": "^7.26.0",
+    "file-loader": "^6.2.0",
+    "raw-loader": "^4.0.2",
+    "webpack": "^5.37.0",
+    "webpack-cli": "^4.7.0",
+    "webpack-dev-server": "^3.11.2"
   }
 }

--- a/src/examples.js
+++ b/src/examples.js
@@ -5,7 +5,7 @@ var fromPairs = require('lodash/fp').fromPairs;
 
 
 function requireExample(name) {
-  return require('raw!./examples/' + name + '.yaml');
+  return require('./examples/' + name + '.yaml');
 }
 
 var examplePairs = [

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -90,6 +90,7 @@ const commonConfig = {
 //////////////////////
 
 const devConfig = {
+  mode: 'development',
   output: {pathinfo: true}
 };
 

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,8 +1,6 @@
 'use strict';
 /* eslint-env node, es6 */
 const path = require('path');
-const webpack = require('webpack');
-
 
 /////////////
 // Utility //
@@ -60,27 +58,25 @@ const commonConfig = {
     'lodash': 'lodash',
     'lodash/fp': '_'
   },
-  plugins: [
-    new webpack.optimize.CommonsChunkPlugin({
-      // Note on ordering:
-      // Each "commons chunk" takes modules shared with any previous chunks,
-      // including other commons. Later commons therefore contain the fewest dependencies.
-      // For clarity, reverse this to be consistent with browser include order.
-      // names: ['util', 'TuringMachine', 'TapeViz', 'StateViz'].reverse()
-      names: ['TMViz'].reverse()
-    })
-  ],
   module: {
-    loaders: [
+    rules: [{
       // copy files verbatim
-      { test: /\.css$/,
-        loader: 'file',
-        query: {
-          name: '[path][name].[ext]',
-          context: srcRoot
-        }
+      test: /\.css$/,
+      loader: 'file-loader',
+      options: {
+        name: '[path][name].[ext]',
+        context: srcRoot
       }
-    ]
+    }, {
+      test: /\.yaml$/,
+      loader: 'raw-loader',
+      options: {
+        esModule: false
+      }
+    }]
+  },
+  stats: {
+    errorDetails: true
   }
 };
 
@@ -95,11 +91,8 @@ const devConfig = {
 };
 
 const prodConfig = {
-  devtool: 'source-map', // for the curious
-  plugins: [
-    new webpack.optimize.OccurrenceOrderPlugin(true),
-    new webpack.optimize.UglifyJsPlugin({compress: {warnings: false}})
-  ]
+  mode: 'production',
+  devtool: 'source-map' // for the curious
 };
 
 const isProduction = (process.env.NODE_ENV === 'production');


### PR DESCRIPTION
This pull request updates the dependencies and webpack configuration file.

`webpack.optimize.OccurrenceOrderPlugin` is now enabled by default (https://github.com/js-dxtools/webpack-validator/issues/155#issuecomment-306384813)
`webpack.optimize.UglifyJsPlugin` is replaced by the Terser plugin which is enabled by default in Webpack v5 (https://webpack.js.org/configuration/optimization/#optimizationminimize, https://webpack.js.org/plugins/terser-webpack-plugin/#getting-started)