### PR TITLE
Support No-operation

### DIFF
--- a/src/TuringMachine.js
+++ b/src/TuringMachine.js
@@ -51,14 +51,16 @@ function move(tape, direction) {
   switch (direction) {
     case MoveHead.right: tape.headRight(); break;
     case MoveHead.left:  tape.headLeft();  break;
+    case MoveHead.none:  tape.headNone();  break;
     default: throw new TypeError('not a valid tape movement: ' + String(direction));
   }
 }
 var MoveHead = Object.freeze({
-  left:  {toString: function () { return 'L'; } },
-  right: {toString: function () { return 'R'; } }
+  left : {toString: function () { return 'L'; } },
+  right: {toString: function () { return 'R'; } },
+  none : {toString: function () { return 'N'; } }
 });
-var MoveTape = Object.freeze({left: MoveHead.right, right: MoveHead.left});
+var MoveTape = Object.freeze({left: MoveHead.right, right: MoveHead.left, none: MoveHead.none});
 
 exports.MoveHead = MoveHead;
 exports.MoveTape = MoveTape;

--- a/src/parser.js
+++ b/src/parser.js
@@ -189,7 +189,7 @@ function parseInstruction(synonyms, table, val) {
       case 'object': return parseInstructionObject(val);
       default: throw new TMSpecError('Invalid instruction type',
         {problemValue: typeof val,
-          info: 'An instruction can be a string (a direction <code>L</code>/<code>R</code> or a synonym)'
+          info: 'An instruction can be a string (a direction <code>L</code>/<code>R</code>/<code>N</code> or a synonym)'
             + ' or a mapping (examples: <code>{R: accept}</code>, <code>{write: \' \', L: start}</code>)'});
     }
   }());
@@ -197,6 +197,7 @@ function parseInstruction(synonyms, table, val) {
 
 var moveLeft = Object.freeze({move: TM.MoveHead.left});
 var moveRight = Object.freeze({move: TM.MoveHead.right});
+var moveNone = Object.freeze({move: TM.MoveHead.none});
 
 // case: direction or synonym
 function parseInstructionString(synonyms, val) {
@@ -204,6 +205,8 @@ function parseInstructionString(synonyms, val) {
     return moveLeft;
   } else if (val === 'R') {
     return moveRight;
+  } else if (val === 'N') {
+    return moveNone;
   }
   // note: this order prevents overriding L/R in synonyms, as that would
   // allow inconsistent notation, e.g. 'R' and {R: ..} being different.
@@ -223,11 +226,11 @@ function parseInstructionObject(val) {
     var badKey;
     if (!Object.keys(val).every(function (key) {
       badKey = key;
-      return key === 'L' || key === 'R' || key === 'write';
+      return key === 'L' || key === 'R' || key === 'N' || key === 'write';
     })) {
       throw new TMSpecError('Unrecognized key',
       {problemValue: badKey,
-      info: 'An instruction always has a tape movement <code>L</code> or <code>R</code>, '
+      info: 'An instruction always has a tape movement <code>L</code> or <code>R</code> or <code>N</code>, '
         + 'and optionally can <code>write</code> a symbol'});
     }
   })();
@@ -242,6 +245,9 @@ function parseInstructionObject(val) {
   } else if ('R' in val) {
     move = TM.MoveHead.right;
     state = val.R;
+  } else if ('N' in val) {
+    move = TM.MoveHead.none;
+    state = val.N;
   } else {
     throw new TMSpecError('Missing movement direction');
   }

--- a/src/tape/Tape.js
+++ b/src/tape/Tape.js
@@ -45,6 +45,8 @@ Tape.prototype.headLeft = function () {
   }
   after.push(before.pop());
 };
+Tape.prototype.headNone = function () {
+};
 
 Tape.prototype.toString = function () {
   return this.tape.toString();


### PR DESCRIPTION
The supported operations could be changed from `{L, R}` to `{L, R, N}`, where N ("None" or "No-operation") would allow the machine to stay on the same tape cell instead of moving left or right.
See also https://en.wikipedia.org/wiki/Turing_machine#Alternative_definitions